### PR TITLE
more consistent style, gh action cleanup

### DIFF
--- a/{{cookiecutter.project_slug}}/.github/workflows/check-manifest.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/check-manifest.yml
@@ -16,10 +16,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install check-manifest
-    - name: Install yt
+    - name: Install {{ cookiecutter.project_slug }}
       shell: bash
       run: |
-        python -m pip install Cython numpy wheel
         python -m pip install --no-build-isolation .
     - name: Init submodules
       uses: snickerbockers/submodules-init@v4

--- a/{{cookiecutter.project_slug}}/.github/workflows/publish-to-pypi.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/publish-to-pypi.yml
@@ -1,6 +1,10 @@
 name: Publish Python distributions to PyPI and TestPyPI
 
-on: push
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
 jobs:
   build-and-publish:

--- a/{{cookiecutter.project_slug}}/.github/workflows/style-checks.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/style-checks.yml
@@ -1,5 +1,5 @@
 name: Style Checks
-on: [pull_request]
+on: [push, pull_request]
 
 jobs:
   flake8:

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -1,0 +1,8 @@
+[tool.black]
+line-length = 88
+target-version = ['py37']
+
+[tool.isort]
+profile = "black"
+combine_as_imports = true
+skip =  ["venv", "benchmarks"]

--- a/{{cookiecutter.project_slug}}/setup.cfg
+++ b/{{cookiecutter.project_slug}}/setup.cfg
@@ -15,7 +15,15 @@ replace = __version__ = '{new_version}'
 universal = 1
 
 [flake8]
-exclude = docs
+max-line-length = 88
+exclude = docs,
+    */__init__.py,                     # avoid spurious "unused import"
+ignore = E203, # Whitespace before ':' (black compatibility)
+    E266, # Too many leading '#' for block comment
+    E302, # Expected 2 blank lines, found 0
+    E501, # Line too long (let Black deal with line-lenght)
+    E741, # Do not use variables named 'I', 'O', or 'l'
+    W503, # Line break occurred before a binary operator (black compatibility)
 
 {%- if cookiecutter.use_pytest == 'y' %}
 [tool:pytest]


### PR DESCRIPTION
This adjusts the style config to avoid isort and black conflicts and to align with yt's. It also updates a few of the github actions: `publish-to-pypi` now includes a check for a tag at the start in addition to the check after all the building. 